### PR TITLE
Adding tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ registration, account recovery, ... screens, please check out the
 
 ## Configuration
 
-This application can be configured using two environment variables:
+This application can be configured using the following environment variables:
 
 - `KRATOS_PUBLIC_URL` (required): The URL where ORY Kratos's Public API is
   located at. If this app and ORY Kratos are running in the same private
@@ -24,6 +24,8 @@ This application can be configured using two environment variables:
   `TLS_CERT_PATH` to enable HTTPS.
 - `KRATOS_BROWSER_URL` (optional) The browser accessible URL where ORY Kratos's
   public API is located, only needed if it differs from `KRATOS_PUBLIC_URL`
+- `ORY_PAT`: A personal access token, used to communicate with Ory's APIs
+- `HYDRA_PUBLIC_URL` The URL where ORY Hydra's Public API is located (APIs that will be used directly in the browser as redirects).
 
 This is the easiest mode as it requires no additional set up. This app runs on
 port `:4455` and ORY Kratos `KRATOS_PUBLIC_URL` URL.

--- a/src/pkg/sdk/index.ts
+++ b/src/pkg/sdk/index.ts
@@ -24,30 +24,36 @@ const kratosBrowserUrl = process.env.KRATOS_BROWSER_URL || apiBaseFrontendUrl
 
 const hydraBaseOptions: any = {}
 
-if (process.env.MOCK_TLS_TERMINATION) {
+if (process.env.TLS_TERMINATION) {
   hydraBaseOptions.headers = { "X-Forwarded-Proto": "https" }
 }
 
 const baseConfig = new Configuration({
   basePath: apiBaseFrontendUrl,
+  baseOptions: hydraBaseOptions,
 })
 
 const frontendConfig = new Configuration({
   ...baseConfig,
+  baseOptions: hydraBaseOptions,
 })
 
 const identityConfig = new Configuration({
   ...baseConfig,
+  'accessToken': process.env.ORY_PAT,
   basePath: apiBaseIdentityUrl,
+  baseOptions: hydraBaseOptions,
 })
 
 const permissionsConfig = new Configuration({
   ...baseConfig,
   basePath: apiBasePermissionsUrlInternal,
+  baseOptions: hydraBaseOptions,
 })
 
 const oauth2Config = new Configuration({
   ...baseConfig,
+  'accessToken': process.env.ORY_PAT,
   basePath: apiBaseOauth2UrlInternal,
   baseOptions: hydraBaseOptions,
 })


### PR DESCRIPTION
Required two changes to get working, neither of which I can say with confidence _should_ be required (am I doing it wrong?)

1. Adding a personal access token. When attempting to use `identityApi.getIdentity`, I was getting 401/403 responses. When I stepped through the code of `getIdentity`, I found that a PAT was required: https://github.com/ory/sdk/blob/ba9de623312e12b99800499b2dcbe20e4fa78feb/clients/kratos/typescript/api.ts#L6790. Once I added the PAT, these requests succeeded. I felt a little uncomfortable by this - is this by design? Given we're at the consent screen, the user has already logged in, right? I would rather have seen consent make a request to an endpoint that used the _user's_ credentials to get information about their identity, an endpoint which would only return information about the currently authenticated user (e.g. https://www.ory.sh/docs/kratos/reference/api#tag/frontend/operation/toSession)
2. Ory tunnel was rewriting https urls to http unless `X-Forwarded-Proto": "https"` was set, so I added it to all the `baseOptions` because I was tired of mucking about in debugging that. See https://ory-community.slack.com/archives/C02MR4DEEGH/p1675812592899859
3. Ory tunnel was not rewriting the host of redirect urls, so it was redirecting to the ory network project url, which didn't have cookies set. I had to patch in the correct (tunnel) host, which was super hacky and directly use env variables, but I was too tired of debugging at that point to go further.

Of these changes, the only one that seems relevant for everyone (e.g. those not using the tunnel) is the PAT, and even then I'm not sure it should be using the admin API.